### PR TITLE
Fix use of default Laravel model namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If you discover any security related issues, please email lahaxe[dot]arnaud[at]g
 - [Mike Robinson](https://github.com/multiwebinc)
 - [Chakphanu Komasathit](https://github.com/chakphanu)
 - [Anne Jan Brouwer](https://github.com/annejan)
+- [Alexis Saettler](https://github.com/asbiin)
 
 ## License
 

--- a/src/Models/U2fKey.php
+++ b/src/Models/U2fKey.php
@@ -30,6 +30,7 @@ class U2fKey extends Model
      */
     public function user()
     {
-        return $this->belongsTo('\App\User');
+        $model = config('auth.providers.users.model');
+        return $this->belongsTo($model);
     }
 }

--- a/src/http/Middleware/U2f.php
+++ b/src/http/Middleware/U2f.php
@@ -1,6 +1,7 @@
 <?php namespace Lahaxearnaud\U2f\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Facades\Auth;
 use Lahaxearnaud\U2f\U2f as LaravelU2f;
 use Lahaxearnaud\U2f\Models\U2fKey;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -48,9 +49,9 @@ class U2f
         }
 
         if (!$this->u2f->check()) {
-            if(!\Auth::guest()){
+            if(!Auth::guest()){
                 if(
-                    U2fKey::where('user_id', '=', \Auth::user()->id)->count()  === 0
+                    U2fKey::where('user_id', '=', Auth::user()->getAuthIdentifier())->count()  === 0
                     && $this->config->get('u2f.byPassUserWithoutKey')
                 ) {
                     return $next($request);


### PR DESCRIPTION
This should fix the use of hard coded `\App\User` references, and other namespaces.
In our project, we have moved model files, so the namespace of User class is not the default one.

`Auth::user()` return a class which implements `Illuminate\Contracts\Auth\Authenticatable`, and it's all we need here, to get the id with `getAuthIdentifier()` method.