### PR TITLE
Add the 'on delete cascade' instruction to foreign key in migration script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All Notable changes to `laravel-u2f` will be documented in this file
 - Nothing
 
 ### Fixed
-- Nothing
+- Add the 'on delete cascade' instruction to foreign key in migration script.
 
 ### Removed
 - Nothing

--- a/database/migrations/2015_05_17_031822_create_u2f_key_table.php
+++ b/database/migrations/2015_05_17_031822_create_u2f_key_table.php
@@ -32,7 +32,7 @@ class CreateU2fKeyTable extends Migration
 
         Schema::table('u2f_key', function(Blueprint $table)
         {
-            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 


### PR DESCRIPTION
Adding the "on delete cascade" to let delete a `User` without handling the deletion of `U2fKey`.