### PR TITLE
Remove odd [request] arg

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -34,7 +34,7 @@ var u2fClient = {
         setTimeout(function () {
             var registerRequests = [{version: request.version, challenge: request.challenge, attestation: 'direct'}];
 
-            u2f.register(request.appId, registerRequests, [request], keys, function (data) {
+            u2f.register(request.appId, registerRequests, keys, function (data) {
                 var form = document.getElementById('form');
                 var reg = document.getElementById('register');
                 var alert = null;


### PR DESCRIPTION
This fixes an error where the callback was being passed as an empty array, thus halting the register request.

It's a simple fix for a huge issue I had.